### PR TITLE
Logging Human Readable Exceptions in absence of exception filter.

### DIFF
--- a/src/main/dot-net/syslog4net/Layout/SyslogLayout.cs
+++ b/src/main/dot-net/syslog4net/Layout/SyslogLayout.cs
@@ -27,7 +27,7 @@ namespace syslog4net.Layout
             IgnoresException = false;  //TODO deal with this. sealed?
 
             this._layout = new PatternLayout("<%syslog-priority>1 %utcdate{yyyy-MM-ddTHH:mm:ss.FFZ} %syslog-hostname %appdomain"
-                + " %syslog-process-id %syslog-message-id %syslog-structured-data %message%newline");
+                + " %syslog-process-id %syslog-message-id %syslog-structured-data %message%newline%exception");
 
             this._layout.AddConverter("syslog-priority", typeof(PriorityConverter));
             this._layout.AddConverter("syslog-hostname", typeof(HostnameConverter));
@@ -52,11 +52,6 @@ namespace syslog4net.Layout
 
                 // truncate the message to SYSLOG_MAX_MESSAGE_LENGTH or fewer bytes
                 string message = stringWriter.ToString();
-
-                if (logEvent.ExceptionObject != null)
-                {
-                    message += Environment.NewLine + logEvent.ExceptionObject.ToString();
-                }
 
                 var utf8 = Encoding.UTF8;
 

--- a/src/main/dot-net/syslog4net/Layout/SyslogLayout.cs
+++ b/src/main/dot-net/syslog4net/Layout/SyslogLayout.cs
@@ -53,6 +53,11 @@ namespace syslog4net.Layout
                 // truncate the message to SYSLOG_MAX_MESSAGE_LENGTH or fewer bytes
                 string message = stringWriter.ToString();
 
+                if (logEvent.ExceptionObject != null)
+                {
+                    message += Environment.NewLine + logEvent.ExceptionObject.ToString();
+                }
+
                 var utf8 = Encoding.UTF8;
 
                 byte[] utfBytes = utf8.GetBytes(message);

--- a/src/test/unit/syslog4net.Tests/Layout/SyslogLayoutTests.cs
+++ b/src/test/unit/syslog4net.Tests/Layout/SyslogLayoutTests.cs
@@ -123,6 +123,8 @@ namespace syslog4net.Tests.Layout
 
             Assert.AreEqual(2048, result.Length);
         }
+
+        [Test]
         public void TestThatWeTruncateLongMessages5555()
         {
             SyslogLayout layout = new SyslogLayout();

--- a/src/test/unit/syslog4net.Tests/Layout/SyslogLayoutTests.cs
+++ b/src/test/unit/syslog4net.Tests/Layout/SyslogLayoutTests.cs
@@ -3,8 +3,6 @@ using System.Text;
 using System.IO;
 using syslog4net.Layout;
 using log4net.Core;
-using log4net.Util;
-using log4net.Filter;
 using log4net.Repository;
 using NUnit.Framework;
 using NSubstitute;
@@ -47,7 +45,8 @@ namespace syslog4net.Tests.Layout
             // just test the message's invariant portions
             Assert.IsTrue(result.StartsWith("<135>1 "));
             Assert.IsTrue(result.Contains("[TEST@12345 EventSeverity=\"DEBUG\" ExceptionType=\"System.Exception\" ExceptionMessage=\"test exception message\"]"));
-            Assert.IsTrue(result.EndsWith("test message" + Environment.NewLine));
+            Assert.IsTrue(result.Contains("test message" + Environment.NewLine));
+            Assert.IsTrue(result.EndsWith("System.Exception: test exception message"));
         }
 
         [Test]


### PR DESCRIPTION
Modifying syslog4net PatternLayout to generate a human readable message on exception in the absence of another filter, i.e. pretty print. Some usage patterns of syslog4net contain exception file logging filters but in their absense it will now use log4net's %exception conversion pattern.

This more closely matches log4net's default implementation.